### PR TITLE
chore: Update Renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,27 +1,24 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-  ],
-  "labels": ["renovate"],
-  "automergeType": "branch",
-  "regexManagers": [
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:base"],
+  labels: ["renovate"],
+  automergeType: "branch",
+  regexManagers: [
     // TODO: Remove this setting when Renovate supports asdf.
     // https://github.com/renovatebot/renovate/issues/4051
     {
-      "fileMatch": ["^.tool-versions$"],
-      "matchStrings": ["^nodejs (?<currentValue>.*)\\n"],
-      "depNameTemplate": "nodejs/node",
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "node",
-    }
+      fileMatch: ["^.tool-versions$"],
+      matchStrings: ["^nodejs (?<currentValue>.*)\\n"],
+      depNameTemplate: "nodejs/node",
+      datasourceTemplate: "github-releases",
+      versioningTemplate: "node",
+    },
   ],
-  "packageRules": [
+  packageRules: [
     {
-      "matchManagers": ["npm"],
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
+      groupName: "npm-non-major",
+      matchManagers: ["npm"],
+      matchUpdateTypes: ["minor", "patch"],
     },
   ],
 }


### PR DESCRIPTION
- Reformatting
- Stop grouping by depType
- Stop automerge
- Add the group name to non-major rule