### PR TITLE
ci: Fix to use only `branches` filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,9 @@ on:
       - 'renovate/**'
 
   pull_request:
-    branches-ignore:
-      - 'renovate/**'
+    branches:
+      - '!renovate/**'
+      - '**'
 
 jobs:
   npm-run:


### PR DESCRIPTION
Because it is not possible to use `branches` and `branches-ignore` at the same time for different events.