### PR TITLE
chore: Remove optional configuration from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,2 @@
 # Configure with an exact version rather than using npm’s default semver range operator.
 save-exact=true
-
-# Disable the installation of optional packages.
-optional=false


### PR DESCRIPTION
I should migrate to `omit`, but that is not what I expect, so I simply remove `optional`.