### PR TITLE
Support emoji shortcodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@webscopeio/react-textarea-autocomplete": "4.9.2",
         "dompurify": "2.4.1",
+        "gemoji": "7.1.0",
         "highlight.js": "11.7.0",
         "marked": "4.2.3",
         "react": "17.0.2",
@@ -19102,6 +19103,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/gemoji": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gemoji/-/gemoji-7.1.0.tgz",
+      "integrity": "sha512-wI0YWDIfQraQMDs0yXAVQiVBZeMm/rIYssf8LZlMDdssKF19YqJKOHkv4zvwtVQTBJ0LNmErv1S+DqlVUudz8g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/gensync": {
@@ -47415,6 +47425,11 @@
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
       }
+    },
+    "gemoji": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gemoji/-/gemoji-7.1.0.tgz",
+      "integrity": "sha512-wI0YWDIfQraQMDs0yXAVQiVBZeMm/rIYssf8LZlMDdssKF19YqJKOHkv4zvwtVQTBJ0LNmErv1S+DqlVUudz8g=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@webscopeio/react-textarea-autocomplete": "4.9.2",
     "dompurify": "2.4.1",
+    "gemoji": "7.1.0",
     "highlight.js": "11.7.0",
     "marked": "4.2.3",
     "react": "17.0.2",

--- a/src/app/components/marktone.tsx
+++ b/src/app/components/marktone.tsx
@@ -8,6 +8,7 @@ import ReactTextareaAutocomplete, {
 import MarktoneRenderer from "../markdown/renderer/marktone-renderer";
 import KintoneClient from "../kintone/kintone-client";
 import MentionReplacer from "../markdown/replacer/mention-replacer";
+import EmojiReplacer from "../markdown/replacer/emoji-replacer";
 import {
   DirectoryEntity,
   DirectoryEntityType,
@@ -27,6 +28,7 @@ interface MarktoneProps {
   replayMentions: ReplyMention[];
   kintoneClient: KintoneClient;
   mentionReplacer: MentionReplacer;
+  emojiReplacer: EmojiReplacer;
 }
 
 interface MentionCandidateItem {
@@ -64,7 +66,8 @@ const MentionCandidate: React.FC<ItemComponentProps<MentionCandidateItem>> = (
  * Marktone component.
  */
 const Marktone: React.FC<MarktoneProps> = (props: MarktoneProps) => {
-  const { originalFormEl, kintoneClient, mentionReplacer } = props;
+  const { originalFormEl, kintoneClient, mentionReplacer, emojiReplacer } =
+    props;
 
   // Setup Marked.js
   marked.setOptions({
@@ -73,7 +76,7 @@ const Marktone: React.FC<MarktoneProps> = (props: MarktoneProps) => {
     headerIds: false,
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore for `listitem()`
-    renderer: new MarktoneRenderer(mentionReplacer),
+    renderer: new MarktoneRenderer(mentionReplacer, emojiReplacer),
   });
 
   /**

--- a/src/app/markdown/renderer/marktone-renderer.ts
+++ b/src/app/markdown/renderer/marktone-renderer.ts
@@ -1,6 +1,7 @@
 import { marked, Renderer } from "marked";
 import hljs from "highlight.js";
 import MentionReplacer from "../replacer/mention-replacer";
+import EmojiReplacer from "../replacer/emoji-replacer";
 import KintoneClient from "../../kintone/kintone-client";
 import { highlightStyles, languageAliases } from "./highlight-settings";
 
@@ -64,6 +65,7 @@ class MarktoneRendererHelper {
 /* eslint-disable class-methods-use-this */
 class MarktoneRenderer extends Renderer {
   private mentionReplacer: MentionReplacer;
+  private emojiReplacer: EmojiReplacer;
   private static MONOSPACE_FONT_FAMILIES: readonly string[] = [
     "SFMono-Regular",
     "Consolas",
@@ -75,10 +77,12 @@ class MarktoneRenderer extends Renderer {
 
   constructor(
     mentionReplacer: MentionReplacer,
+    emojiReplacer: EmojiReplacer,
     options?: marked.MarkedOptions
   ) {
     super(options);
     this.mentionReplacer = mentionReplacer;
+    this.emojiReplacer = emojiReplacer;
     this.monospaceFontFamiliesString =
       MarktoneRenderer.MONOSPACE_FONT_FAMILIES.map(
         (familyName) => `'${familyName}'`
@@ -102,7 +106,9 @@ class MarktoneRenderer extends Renderer {
   }
 
   html(html: string): string {
-    return this.mentionReplacer.replaceMention(html);
+    return this.mentionReplacer.replaceMention(
+      this.emojiReplacer.replaceEmoji(html)
+    );
   }
 
   code(code: string, language: string, isEscaped: boolean): string {
@@ -183,7 +189,9 @@ class MarktoneRenderer extends Renderer {
   //
 
   text(text: string): string {
-    return this.mentionReplacer.replaceMention(text);
+    return this.mentionReplacer.replaceMention(
+      this.emojiReplacer.replaceEmoji(text)
+    );
   }
 
   codespan(code: string): string {

--- a/src/app/markdown/replacer/emoji-replacer.ts
+++ b/src/app/markdown/replacer/emoji-replacer.ts
@@ -1,0 +1,14 @@
+import { nameToEmoji } from "gemoji";
+
+class EmojiReplacer {
+  private static emojiRegExp = /:([-+]?\w+):/g;
+
+  replaceEmoji(text: string): string {
+    const replacer = (match: string, name: string): string => {
+      return nameToEmoji[name] || match;
+    };
+    return text.replace(EmojiReplacer.emojiRegExp, replacer);
+  }
+}
+
+export default EmojiReplacer;

--- a/src/app/marktone-handler.tsx
+++ b/src/app/marktone-handler.tsx
@@ -4,11 +4,13 @@ import ReactDOM from "react-dom";
 import KintoneClient from "./kintone/kintone-client";
 import HTMLElementUtil from "./kintone/html-element-util";
 import MentionReplacer from "./markdown/replacer/mention-replacer";
+import EmojiReplacer from "./markdown/replacer/emoji-replacer";
 import Marktone, { ReplyMention } from "./components/marktone";
 
 class MarktoneHandler {
   private readonly kintoneClient: KintoneClient;
   private readonly mentionReplacer: MentionReplacer;
+  private readonly emojiReplacer: EmojiReplacer;
 
   private static isExpandedStatusChangedCommentFormRecord(
     record: MutationRecord
@@ -30,6 +32,7 @@ class MarktoneHandler {
   constructor(kintoneClient: KintoneClient) {
     this.kintoneClient = kintoneClient;
     this.mentionReplacer = new MentionReplacer(kintoneClient);
+    this.emojiReplacer = new EmojiReplacer();
   }
 
   handle(): void {
@@ -81,6 +84,7 @@ class MarktoneHandler {
         replayMentions={replyMentions}
         kintoneClient={this.kintoneClient}
         mentionReplacer={this.mentionReplacer}
+        emojiReplacer={this.emojiReplacer}
       />,
       marktoneContainer
     );


### PR DESCRIPTION
Hi,

Thank you for developing very useful browser extension.

I tried adding support for `:emoji_name:` style emoji shortcodes.
For example, `:thinking:` renders :thinking: emoji.

I'll be glad if you like this feature.