### PR TITLE
ci: delete the `build-storybook` job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,13 +50,3 @@ jobs:
         uses: ./.github/actions/setup-node
       - name: Package extension
         run: npm run package
-
-  build-storybook:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-node
-      - name: Build Storybook
-        run: npm run build-storybook


### PR DESCRIPTION
It was replaced with the Chromatic workflow.