### PR TITLE
chore: uninstall @types/dompurify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@testing-library/user-event": "14.5.2",
         "@types/archiver": "6.0.3",
         "@types/chrome": "0.0.284",
-        "@types/dompurify": "3.2.0",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
         "@types/webscopeio__react-textarea-autocomplete": "4.7.5",
@@ -2587,17 +2586,6 @@
       "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@testing-library/user-event": "14.5.2",
     "@types/archiver": "6.0.3",
     "@types/chrome": "0.0.284",
-    "@types/dompurify": "3.2.0",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@types/webscopeio__react-textarea-autocomplete": "4.7.5",


### PR DESCRIPTION
DOMPurify provides its own type definitions, so it is no longer necessary.